### PR TITLE
Fix numberFormatPipe for 0 value

### DIFF
--- a/src/app/systelab-translate/number-format.pipe.ts
+++ b/src/app/systelab-translate/number-format.pipe.ts
@@ -11,7 +11,7 @@ export class NumberFormatPipe implements PipeTransform {
 
 	public transform(value: number, precision?: string, units?: string, priorSymbol?: string, defaultSymbolWhenNull?: string, ...args: string[]): string {
 
-		if (value) {
+		if (value || value == 0) {
 			if (!precision) {
 				precision = '1.0-2';
 			}

--- a/src/test/number-format.pipe.spec.ts
+++ b/src/test/number-format.pipe.spec.ts
@@ -79,5 +79,10 @@ describe('Pipe: NumberFormatPipe', () => {
 		expect(pipe.transform(3.3323335, '1dsfas3333423422', '%', '<'))
 			.toBe('');
 	});
+
+	it('check number format with 0.0', () => {
+		expect(pipe.transform(0.0, '1.0-2', '', ''))
+			.toBe('0');
+	});
 });
 


### PR DESCRIPTION
Fix the defect: The pipe returns ' ' for 0 value instead of 0.