### PR TITLE
Bugfix/90

### DIFF
--- a/projects/systelab-translate/package.json
+++ b/projects/systelab-translate/package.json
@@ -7,7 +7,7 @@
     "Translate",
     "i18n"
   ],
-  "version": "11.1.1",
+  "version": "11.1.2",
   "license": "MIT",
   "homepage": "https://github.com/systelab/systelab-translate.git",
   "repository": {

--- a/projects/systelab-translate/src/lib/date-util/date-util.ts
+++ b/projects/systelab-translate/src/lib/date-util/date-util.ts
@@ -35,9 +35,9 @@ export class DateUtil {
 		if (!date) {
 			return undefined;
 		}
-		const formatedDate = (fullYear) ? this.formatDateFullYear(date) : this.formatDate(date);
-		const formatedHour = this.formatTime(date, withSeconds);
-		return formatedDate + ' ' + formatedHour;
+		const formattedDate = (fullYear) ? this.formatDateFullYear(date) : this.formatDate(date);
+		const formattedHour = this.formatTime(date, withSeconds);
+		return formattedDate + ' ' + formattedHour;
 	}
 
 	public formatMonthAndYear(date: Date): string {
@@ -87,91 +87,20 @@ export class DateUtil {
 	}
 
 	public getDateFormat(isFullYear = false): string {
-		let stringDateFormat = '';
-		switch (this.locale) {
-			case 'en-US':
-				stringDateFormat = 'M/d/yy';
-				break;
-			case 'ko-KO':
-				stringDateFormat = 'yy. M. d';
-				break;
-			case 'pl-PL':
-			case 'lt-LT':
-				stringDateFormat = 'yy-MM-dd';
-				break;
-			case 'pt-PT':
-			case 'pt-BR':
-			case 'nl-NL':
-				stringDateFormat = 'dd-MM-yy';
-				break;
-			case 'sk-SK':
-			case 'ru-RU':
-				stringDateFormat = 'd.M.yy';
-				break;
-			case 'zh-ZH':
-				stringDateFormat = 'yy-M-d';
-				break;
-			case 'de-DE':
-				stringDateFormat = 'dd.MM.yy';
-				break;
-			case 'th-TH':
-				stringDateFormat = 'd/M/yy';
-				break;
-			case 'ja-JA':
-				stringDateFormat = 'yy/MM/dd';
-				break;
-			default:
-				stringDateFormat = 'dd/MM/yy';
-				break;
-		}
+		let stringDateFormat = this.getLocalizedStringDateFormat(this.locale);
+
 		if (isFullYear) {
 			stringDateFormat = stringDateFormat.replace('yy', 'yyyy');
 			if (this.locale === 'en-US') {
-				stringDateFormat = stringDateFormat.replace('M', 'MM');
-				stringDateFormat = stringDateFormat.replace('D', 'dd');
+				stringDateFormat = stringDateFormat.replace('M', 'MM').replace('d', 'dd');
 			}
 		}
 		return stringDateFormat;
 	}
 
 	public getDateFormatForDatePicker(isFullYear = false): string {
-		let stringDateFormat = '';
-		switch (this.locale) {
-			case 'en-US':
-				stringDateFormat = 'm/d/y';
-				break;
-			case 'ko-KO':
-				stringDateFormat = 'y. m. d';
-				break;
-			case 'pl-PL':
-			case 'lt-LT':
-				stringDateFormat = 'y-mm-dd';
-				break;
-			case 'pt-PT':
-			case 'pt-BR':
-			case 'nl-NL':
-				stringDateFormat = 'dd-mm-y';
-				break;
-			case 'sk-SK':
-			case 'ru-RU':
-				stringDateFormat = 'd.m.y';
-				break;
-			case 'zh-CN':
-				stringDateFormat = 'y-m-d';
-				break;
-			case 'de-DE':
-				stringDateFormat = 'dd.mm.y';
-				break;
-			case 'th-TH':
-				stringDateFormat = 'd/m/y';
-				break;
-			case 'ja-JA':
-				stringDateFormat = 'y/mm/dd';
-				break;
-			default:
-				stringDateFormat = 'dd/mm/y';
-				break;
-		}
+		let stringDateFormat = this.getLocalizedDateFormatForDatePicker(this.locale);
+
 		if (isFullYear) {
 			stringDateFormat = stringDateFormat.replace('y', 'yy');
 			if (this.locale === 'en-US') {
@@ -250,5 +179,63 @@ export class DateUtil {
 		]);
 		const locale: Locale = localeForSystelabLocale.get(localeString)
 		return locale ? locale : enUS;
+	}
+
+	private getLocalizedStringDateFormat(locale: string): string {
+		switch (locale) {
+			case 'en-US':
+				return 'M/d/yy';
+			case 'ko-KO':
+				return 'yy. M. d';
+			case 'pl-PL':
+			case 'lt-LT':
+				return 'yy-MM-dd';
+			case 'pt-PT':
+			case 'pt-BR':
+			case 'nl-NL':
+				return 'dd-MM-yy';
+			case 'sk-SK':
+			case 'ru-RU':
+				return 'd.M.yy';
+			case 'zh-ZH':
+				return 'yy-M-d';
+			case 'de-DE':
+				return 'dd.MM.yy';
+			case 'th-TH':
+				return 'd/M/yy';
+			case 'ja-JA':
+				return 'yy/MM/dd';
+			default:
+				return 'dd/MM/yy';
+		}
+	}
+
+	private getLocalizedDateFormatForDatePicker(locale: string): string {
+		switch (locale) {
+			case 'en-US':
+				return 'm/d/y';
+			case 'ko-KO':
+				return 'y. m. d';
+			case 'pl-PL':
+			case 'lt-LT':
+				return 'y-mm-dd';
+			case 'pt-PT':
+			case 'pt-BR':
+			case 'nl-NL':
+				return 'dd-mm-y';
+			case 'sk-SK':
+			case 'ru-RU':
+				return 'd.m.y';
+			case 'zh-CN':
+				return 'y-m-d';
+			case 'de-DE':
+				return 'dd.mm.y';
+			case 'th-TH':
+				return 'd/m/y';
+			case 'ja-JA':
+				return 'y/mm/dd';
+			default:
+				return 'dd/mm/y';
+		}
 	}
 }

--- a/projects/systelab-translate/src/lib/date-util/date-util.ts
+++ b/projects/systelab-translate/src/lib/date-util/date-util.ts
@@ -86,12 +86,12 @@ export class DateUtil {
 		}
 	}
 
-	public getDateFormat(isFullYear = false): string {
-		return this.getLocalizedStringDateFormat(this.locale, isFullYear);
+	public getDateFormat(fullDateFormat = false): string {
+		return this.getLocalizedStringDateFormat(this.locale, fullDateFormat);
 	}
 
-	public getDateFormatForDatePicker(isFullYear = false): string {
-		return this.getLocalizedDateFormatForDatePicker(this.locale, isFullYear);
+	public getDateFormatForDatePicker(fullDateFormat = false): string {
+		return this.getLocalizedDateFormatForDatePicker(this.locale, fullDateFormat);
 	}
 
 	public getFirstDayOfWeek(): number {
@@ -160,15 +160,15 @@ export class DateUtil {
 			['sk-SK', sk], ['ru', ru], ['ru-RU', ru], ['zh', zhCN], ['zh-CN', zhCN], ['de', de], ['de-DE', de],
 			['th', th], ['th-TH', th], ['ja', ja], ['ja-JA', ja], ['ko', ko], ['ko-KR', ko], ['nl', nl], ['nl-NL', nl],
 		]);
-		const locale: Locale = localeForSystelabLocale.get(localeString)
+		const locale: Locale = localeForSystelabLocale.get(localeString);
 		return locale ? locale : enUS;
 	}
 
-	private getLocalizedStringDateFormat(locale: string, isFullYear = false): string {
-		const year = isFullYear ? 'yyyy' : 'yy';
+	private getLocalizedStringDateFormat(locale: string, fullDateFormat = false): string {
+		const year = fullDateFormat ? 'yyyy' : 'yy';
 		switch (locale) {
 			case 'en-US':
-				return isFullYear ? `MM/dd/${year}` : `M/d/${year}`;
+				return fullDateFormat ? `MM/dd/${year}` : `M/d/${year}`;
 			case 'ko-KO':
 				return `${year}. M. d`;
 			case 'pl-PL':
@@ -194,11 +194,11 @@ export class DateUtil {
 		}
 	}
 
-	private getLocalizedDateFormatForDatePicker(locale: string, isFullYear = false): string {
-		const year = isFullYear ? 'yy' : 'y';
+	private getLocalizedDateFormatForDatePicker(locale: string, fullDateFormat = false): string {
+		const year = fullDateFormat ? 'yy' : 'y';
 		switch (locale) {
 			case 'en-US':
-				return isFullYear ? `mm/dd/${year}` : `m/d/${year}`;
+				return fullDateFormat ? `mm/dd/${year}` : `m/d/${year}`;
 			case 'ko-KO':
 				return `${year}. m. d`;
 			case 'pl-PL':

--- a/projects/systelab-translate/src/lib/date-util/date-util.ts
+++ b/projects/systelab-translate/src/lib/date-util/date-util.ts
@@ -87,28 +87,11 @@ export class DateUtil {
 	}
 
 	public getDateFormat(isFullYear = false): string {
-		let stringDateFormat = this.getLocalizedStringDateFormat(this.locale);
-
-		if (isFullYear) {
-			stringDateFormat = stringDateFormat.replace('yy', 'yyyy');
-			if (this.locale === 'en-US') {
-				stringDateFormat = stringDateFormat.replace('M', 'MM').replace('d', 'dd');
-			}
-		}
-		return stringDateFormat;
+		return this.getLocalizedStringDateFormat(this.locale, isFullYear);
 	}
 
 	public getDateFormatForDatePicker(isFullYear = false): string {
-		let stringDateFormat = this.getLocalizedDateFormatForDatePicker(this.locale);
-
-		if (isFullYear) {
-			stringDateFormat = stringDateFormat.replace('y', 'yy');
-			if (this.locale === 'en-US') {
-				stringDateFormat = stringDateFormat.replace('m', 'mm');
-				stringDateFormat = stringDateFormat.replace('d', 'dd');
-			}
-		}
-		return stringDateFormat;
+		return this.getLocalizedDateFormatForDatePicker(this.locale, isFullYear);
 	}
 
 	public getFirstDayOfWeek(): number {
@@ -181,61 +164,63 @@ export class DateUtil {
 		return locale ? locale : enUS;
 	}
 
-	private getLocalizedStringDateFormat(locale: string): string {
+	private getLocalizedStringDateFormat(locale: string, isFullYear = false): string {
+		const year = isFullYear ? 'yyyy' : 'yy';
 		switch (locale) {
 			case 'en-US':
-				return 'M/d/yy';
+				return isFullYear ? `MM/dd/${year}` : `M/d/${year}`;
 			case 'ko-KO':
-				return 'yy. M. d';
+				return `${year}. M. d`;
 			case 'pl-PL':
 			case 'lt-LT':
-				return 'yy-MM-dd';
+				return `${year}-MM-dd`;
 			case 'pt-PT':
 			case 'pt-BR':
 			case 'nl-NL':
-				return 'dd-MM-yy';
+				return `dd-MM-${year}`;
 			case 'sk-SK':
 			case 'ru-RU':
-				return 'd.M.yy';
+				return `d.M.${year}`;
 			case 'zh-ZH':
-				return 'yy-M-d';
+				return `${year}-M-d`;
 			case 'de-DE':
-				return 'dd.MM.yy';
+				return `dd.MM.${year}`;
 			case 'th-TH':
-				return 'd/M/yy';
+				return `d/M/${year}`;
 			case 'ja-JA':
-				return 'yy/MM/dd';
+				return `${year}/MM/dd`;
 			default:
-				return 'dd/MM/yy';
+				return `dd/MM/${year}`;
 		}
 	}
 
-	private getLocalizedDateFormatForDatePicker(locale: string): string {
+	private getLocalizedDateFormatForDatePicker(locale: string, isFullYear = false): string {
+		const year = isFullYear ? 'yy' : 'y';
 		switch (locale) {
 			case 'en-US':
-				return 'm/d/y';
+				return isFullYear ? `mm/dd/${year}` : `m/d/${year}`;
 			case 'ko-KO':
-				return 'y. m. d';
+				return `${year}. m. d`;
 			case 'pl-PL':
 			case 'lt-LT':
-				return 'y-mm-dd';
+				return `${year}-mm-dd`;
 			case 'pt-PT':
 			case 'pt-BR':
 			case 'nl-NL':
-				return 'dd-mm-y';
+				return `dd-mm-${year}`;
 			case 'sk-SK':
 			case 'ru-RU':
-				return 'd.m.y';
+				return `d.m.${year}`;
 			case 'zh-CN':
-				return 'y-m-d';
+				return `${year}-m-d`;
 			case 'de-DE':
-				return 'dd.mm.y';
+				return `dd.mm.${year}`;
 			case 'th-TH':
-				return 'd/m/y';
+				return `d/m/${year}`;
 			case 'ja-JA':
-				return 'y/mm/dd';
+				return `${year}/mm/dd`;
 			default:
-				return 'dd/mm/y';
+				return `dd/mm/${year}`;
 		}
 	}
 }

--- a/projects/systelab-translate/src/test/date.service.spec.ts
+++ b/projects/systelab-translate/src/test/date.service.spec.ts
@@ -9,14 +9,14 @@ const getExampleDate = (oneDigitDay = false): Date => {
 	const month = oneDigitDay ? 4 : 0;
 	date.setFullYear(2016, month, day);
 	return date;
-}
+};
 
 const getExampleDateTime = (oneDigitDay = false): Date => {
 	const date = getExampleDate(oneDigitDay);
 	date.setHours(21);
 	date.setMinutes(0, 0, 0);
 	return date;
-}
+};
 
 describe('Date Service', () => {
 	let service: I18nService;

--- a/projects/systelab-translate/src/test/date.service.spec.ts
+++ b/projects/systelab-translate/src/test/date.service.spec.ts
@@ -3,6 +3,21 @@ import { TestBed } from '@angular/core/testing';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 
+const getExampleDate = (oneDigitDay = false): Date => {
+	const date = new Date();
+	const day = oneDigitDay ? 1 : 28;
+	const month = oneDigitDay ? 4 : 0;
+	date.setFullYear(2016, month, day);
+	return date;
+}
+
+const getExampleDateTime = (oneDigitDay = false): Date => {
+	const date = getExampleDate(oneDigitDay);
+	date.setHours(21);
+	date.setMinutes(0, 0, 0);
+	return date;
+}
+
 describe('Date Service', () => {
 	let service: I18nService;
 
@@ -172,18 +187,3 @@ describe('Date Service', () => {
 	});
 
 });
-
-function getExampleDate(oneDigitDay = false): Date {
-	const date = new Date();
-	const day = oneDigitDay ? 1 : 28;
-	const month = oneDigitDay ? 4 : 0;
-	date.setFullYear(2016, month, day);
-	return date;
-}
-
-function getExampleDateTime(oneDigitDay = false): Date {
-	const date = getExampleDate(oneDigitDay);
-	date.setHours(21);
-	date.setMinutes(0, 0, 0);
-	return date;
-}

--- a/projects/systelab-translate/src/test/date.service.spec.ts
+++ b/projects/systelab-translate/src/test/date.service.spec.ts
@@ -2,6 +2,7 @@ import { httpLoaderFactory, I18nService } from '../public-api';
 import { TestBed } from '@angular/core/testing';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
+import {DateUtil} from '../lib/date-util/date-util';
 
 const getExampleDate = (oneDigitDay = false): Date => {
 	const date = new Date();
@@ -55,6 +56,58 @@ describe('Date Service', () => {
 					.toBe('28 ene');
 				done();
 			});
+	});
+
+	it('Format a date for Datepicker', done => {
+		const expectations = {
+			'en-US': 'm/d/y',
+			'ko-KO': 'y. m. d',
+			'pl-PL': 'y-mm-dd',
+			'lt-LT': 'y-mm-dd',
+			'pt-PT': 'dd-mm-y',
+			'pt-BR': 'dd-mm-y',
+			'nl-NL': 'dd-mm-y',
+			'sk-SK': 'd.m.y',
+			'ru-RU': 'd.m.y',
+			'zh-CN': 'y-m-d',
+			'de-DE': 'dd.mm.y',
+			'th-TH': 'd/m/y',
+			'ja-JA': 'y/mm/dd',
+			'es-ES': 'dd/mm/y',
+			'ca-ES': 'dd/mm/y',
+		};
+		const dateUtil = new DateUtil('en-US');
+		Object.keys(expectations).forEach(key => {
+			dateUtil.setLocale(key);
+			expect(dateUtil.getDateFormatForDatePicker()).toBe(expectations[key]);
+		});
+		done();
+	});
+
+	it('Localized String Date Format', done => {
+		const expectations = {
+			'en-US': 'M/d/yy',
+			'ko-KO': 'yy. M. d',
+			'pl-PL': 'yy-MM-dd',
+			'lt-LT': 'yy-MM-dd',
+			'pt-PT': 'dd-MM-yy',
+			'pt-BR': 'dd-MM-yy',
+			'nl-NL': 'dd-MM-yy',
+			'sk-SK': 'd.M.yy',
+			'ru-RU': 'd.M.yy',
+			'zh-ZH': 'yy-M-d',
+			'de-DE': 'dd.MM.yy',
+			'th-TH': 'd/M/yy',
+			'ja-JA': 'yy/MM/dd',
+			'es-ES': 'dd/MM/yy',
+			'ca-ES': 'dd/MM/yy',
+		};
+		const dateUtil = new DateUtil('en-US');
+		Object.keys(expectations).forEach(key => {
+			dateUtil.setLocale(key);
+			expect(dateUtil.getDateFormat()).toBe(expectations[key]);
+		});
+		done();
 	});
 
 	it('Format a date in USA', (done) => {

--- a/projects/systelab-translate/src/test/date.service.spec.ts
+++ b/projects/systelab-translate/src/test/date.service.spec.ts
@@ -45,12 +45,14 @@ describe('Date Service', () => {
 	it('Format a date in USA', (done) => {
 		service.use('en-US')
 			.subscribe(() => {
-				const date = new Date();
-				date.setFullYear(2016, 0, 28);
+				const date = getExampleDate();
+				const dateWith1DigitDay = getExampleDate(true);
 				expect(service.formatDate(date))
 					.toBe('1/28/16');
 				expect(service.formatDateFullYear(date))
 					.toBe('01/28/2016');
+				expect(service.formatDateFullYear(dateWith1DigitDay))
+					.toBe('05/01/2016');
 				done();
 			});
 	});
@@ -80,10 +82,7 @@ describe('Date Service', () => {
 	it('Format a time and a date and time', (done) => {
 		service.use('es-ES')
 			.subscribe(() => {
-				const date = new Date();
-				date.setFullYear(2016, 0, 28);
-				date.setHours(21);
-				date.setMinutes(0, 0, 0);
+				const date = getExampleDateTime();
 				expect(service.formatTime(date))
 					.toBe('21:00');
 				expect(service.formatDateTime(date))
@@ -95,10 +94,7 @@ describe('Date Service', () => {
 	it('Format a time and a date and time in USA', (done) => {
 		service.use('en-US')
 			.subscribe(() => {
-				const date = new Date();
-				date.setFullYear(2016, 0, 28);
-				date.setHours(21);
-				date.setMinutes(0, 0, 0);
+				const date = getExampleDateTime();
 				expect(service.formatTime(date))
 					.toBe('09:00 PM');
 				expect(service.formatDateTime(date))
@@ -110,8 +106,7 @@ describe('Date Service', () => {
 	it('Get dates at the begging of the day, at the end and at noon', (done) => {
 		service.use('es-ES')
 			.subscribe(() => {
-				const date = new Date();
-				date.setFullYear(2016, 0, 28);
+				const date = getExampleDate();
 				date.setHours(21);
 				expect(service.formatDateTime(service.getDateFrom(date)))
 					.toBe('28/01/16 00:00');
@@ -126,10 +121,7 @@ describe('Date Service', () => {
 	it('Format a date and time with AM/PM', (done) => {
 		service.use('es-ES')
 			.subscribe(() => {
-				const date = new Date();
-				date.setFullYear(2016, 0, 28);
-				date.setHours(21);
-				date.setMinutes(0, 0, 0);
+				const date = getExampleDateTime();
 				expect(service.formatTime(date))
 					.toBe('21:00');
 				expect(service.formatDateTime(date))
@@ -143,16 +135,16 @@ describe('Date Service', () => {
 	it('Format a date and time in USA with AM/PM', (done) => {
 		service.use('en-US')
 			.subscribe(() => {
-				const date = new Date();
-				date.setFullYear(2016, 0, 28);
-				date.setHours(21);
-				date.setMinutes(0, 0, 0);
+				const date = getExampleDateTime();
+				const dateWithOneDigitDay = getExampleDateTime(true);
 				expect(service.formatTime(date))
 					.toBe('09:00 PM');
 				expect(service.formatDateTime(date))
 					.toBe('1/28/16 09:00 PM');
 				expect(service.formatDateTime(date, false, true))
 					.toBe('1/28/16 09:00:00 PM');
+				expect(service.formatDateTime(dateWithOneDigitDay, false, true))
+					.toBe('5/1/16 09:00:00 PM');
 				done();
 			});
 	});
@@ -180,3 +172,18 @@ describe('Date Service', () => {
 	});
 
 });
+
+function getExampleDate(oneDigitDay = false): Date {
+	const date = new Date();
+	const day = oneDigitDay ? 1 : 28;
+	const month = oneDigitDay ? 4 : 0;
+	date.setFullYear(2016, month, day);
+	return date;
+}
+
+function getExampleDateTime(oneDigitDay = false): Date {
+	const date = getExampleDate(oneDigitDay);
+	date.setHours(21);
+	date.setMinutes(0, 0, 0);
+	return date;
+}

--- a/projects/systelab-translate/src/test/date.service.spec.ts
+++ b/projects/systelab-translate/src/test/date.service.spec.ts
@@ -19,6 +19,16 @@ const getExampleDateTime = (oneDigitDay = false): Date => {
 	return date;
 };
 
+const expectGetDateFormatForDatePicker = (locale: string, expectedDateFormat: string): void => {
+	const dateUtil = new DateUtil(locale);
+	expect(dateUtil.getDateFormatForDatePicker()).toBe(expectedDateFormat);
+};
+
+const expectGetDateFormat = (locale: string, expectedDateFormat: string): void => {
+	const dateUtil = new DateUtil(locale);
+	expect(dateUtil.getDateFormat()).toBe(expectedDateFormat);
+};
+
 describe('Date Service', () => {
 	let service: I18nService;
 
@@ -59,54 +69,40 @@ describe('Date Service', () => {
 	});
 
 	it('Format a date for Datepicker', done => {
-		const expectations = {
-			'en-US': 'm/d/y',
-			'ko-KO': 'y. m. d',
-			'pl-PL': 'y-mm-dd',
-			'lt-LT': 'y-mm-dd',
-			'pt-PT': 'dd-mm-y',
-			'pt-BR': 'dd-mm-y',
-			'nl-NL': 'dd-mm-y',
-			'sk-SK': 'd.m.y',
-			'ru-RU': 'd.m.y',
-			'zh-CN': 'y-m-d',
-			'de-DE': 'dd.mm.y',
-			'th-TH': 'd/m/y',
-			'ja-JA': 'y/mm/dd',
-			'es-ES': 'dd/mm/y',
-			'ca-ES': 'dd/mm/y',
-		};
-		const dateUtil = new DateUtil('en-US');
-		Object.keys(expectations).forEach(key => {
-			dateUtil.setLocale(key);
-			expect(dateUtil.getDateFormatForDatePicker()).toBe(expectations[key]);
-		});
+		expectGetDateFormatForDatePicker('en-US', 'm/d/y');
+		expectGetDateFormatForDatePicker('ko-KO', 'y. m. d');
+		expectGetDateFormatForDatePicker('pl-PL', 'y-mm-dd');
+		expectGetDateFormatForDatePicker('lt-LT', 'y-mm-dd');
+		expectGetDateFormatForDatePicker('pt-PT', 'dd-mm-y');
+		expectGetDateFormatForDatePicker('pt-BR', 'dd-mm-y');
+		expectGetDateFormatForDatePicker('nl-NL', 'dd-mm-y');
+		expectGetDateFormatForDatePicker('sk-SK', 'd.m.y');
+		expectGetDateFormatForDatePicker('ru-RU', 'd.m.y');
+		expectGetDateFormatForDatePicker('zh-CN', 'y-m-d');
+		expectGetDateFormatForDatePicker('de-DE', 'dd.mm.y');
+		expectGetDateFormatForDatePicker('th-TH', 'd/m/y');
+		expectGetDateFormatForDatePicker('ja-JA', 'y/mm/dd');
+		expectGetDateFormatForDatePicker('es-ES', 'dd/mm/y');
+		expectGetDateFormatForDatePicker('ca-ES', 'dd/mm/y');
 		done();
 	});
 
 	it('Localized String Date Format', done => {
-		const expectations = {
-			'en-US': 'M/d/yy',
-			'ko-KO': 'yy. M. d',
-			'pl-PL': 'yy-MM-dd',
-			'lt-LT': 'yy-MM-dd',
-			'pt-PT': 'dd-MM-yy',
-			'pt-BR': 'dd-MM-yy',
-			'nl-NL': 'dd-MM-yy',
-			'sk-SK': 'd.M.yy',
-			'ru-RU': 'd.M.yy',
-			'zh-ZH': 'yy-M-d',
-			'de-DE': 'dd.MM.yy',
-			'th-TH': 'd/M/yy',
-			'ja-JA': 'yy/MM/dd',
-			'es-ES': 'dd/MM/yy',
-			'ca-ES': 'dd/MM/yy',
-		};
-		const dateUtil = new DateUtil('en-US');
-		Object.keys(expectations).forEach(key => {
-			dateUtil.setLocale(key);
-			expect(dateUtil.getDateFormat()).toBe(expectations[key]);
-		});
+		expectGetDateFormat('en-US', 'M/d/yy');
+		expectGetDateFormat('ko-KO', 'yy. M. d');
+		expectGetDateFormat('pl-PL', 'yy-MM-dd');
+		expectGetDateFormat('lt-LT', 'yy-MM-dd');
+		expectGetDateFormat('pt-PT', 'dd-MM-yy');
+		expectGetDateFormat('pt-BR', 'dd-MM-yy');
+		expectGetDateFormat('nl-NL', 'dd-MM-yy');
+		expectGetDateFormat('sk-SK', 'd.M.yy');
+		expectGetDateFormat('ru-RU', 'd.M.yy');
+		expectGetDateFormat('zh-ZH', 'yy-M-d');
+		expectGetDateFormat('de-DE', 'dd.MM.yy');
+		expectGetDateFormat('th-TH', 'd/M/yy');
+		expectGetDateFormat('ja-JA', 'yy/MM/dd');
+		expectGetDateFormat('es-ES', 'dd/MM/yy');
+		expectGetDateFormat('ca-ES', 'dd/MM/yy');
 		done();
 	});
 

--- a/projects/systelab-translate/src/test/i18n.service.spec.ts
+++ b/projects/systelab-translate/src/test/i18n.service.spec.ts
@@ -40,7 +40,7 @@ describe('Translate Service', () => {
 					.toBe('Day');
 				done();
 			},
-				(error) => {
+				() => {
 				});
 	});
 
@@ -329,7 +329,7 @@ describe('Translate Service', () => {
 						.toBe('Day');
 					done();
 				},
-				(error) => {
+				() => {
 				});
 	});
 


### PR DESCRIPTION
Related issue #90 

This PR solved the problem formatting full year dates in en-US. 

Scenario tests has been updated according with the returning two digit days always.

After -> 12/1/2020
Now -> 12/01/2020