### PR TITLE
Bundles path not found #178 v19.0.x

### DIFF
--- a/projects/systelab-translate/package.json
+++ b/projects/systelab-translate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-translate",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "license": "MIT",
   "description": "The internationalization (i18n) library for Systelab",
   "keywords": [

--- a/projects/systelab-translate/src/lib/localizable-translate-static-loader.ts
+++ b/projects/systelab-translate/src/lib/localizable-translate-static-loader.ts
@@ -1,5 +1,4 @@
-
-import { Observable, of as observableOf, forkJoin as observableForkJoin } from 'rxjs';
+import { forkJoin as observableForkJoin, Observable, of as observableOf } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { TranslateLoader } from '@ngx-translate/core';
 import { HttpClient } from '@angular/common/http';
@@ -9,19 +8,22 @@ export class LocalizableTranslateStaticLoader implements TranslateLoader {
 
 	protected prefix = '';
 
-	constructor(private http: HttpClient, private location: Location) {
-		if (!(window.location.pathname === '/' || window.location.pathname === '/context.html')) {
-			this.prefix = window.location.pathname;
+	constructor(private http: HttpClient, protected location: Location) {
+		if (!(this.getWindowPathname() === '/' || this.getWindowPathname() === '/context.html')) {
+			this.prefix = this.getWindowPathname();
 			if (this.prefix.endsWith('index.html')) {
 				// That's the case of Electron when starting from local file.
-				this.prefix = this.prefix.substr(0, this.prefix.length - 10);
+				this.prefix = this.prefix.slice(0, this.prefix.length - 10);
 			}
 			if (this.prefix.endsWith('/')) {
-				this.prefix = this.prefix.substr(0, this.prefix.length - 1);
+				this.prefix = this.prefix.slice(0, this.prefix.length - 1);
 			}
-			if (this.prefix.endsWith(this.location.path())) {
+			// Check if the URL contains parameters (i.e.: identity provider redirection) and remove them
+			const routePath = this.location.path() ? this.location.path()
+				.split('?')[0] : undefined;
+			if (routePath && this.prefix.endsWith(routePath)) {
 				// When starting from an Angular application route
-				this.prefix = this.prefix.substr(0, this.prefix.length - this.location.path().length);
+				this.prefix = this.prefix.slice(0, this.prefix.length - routePath.length);
 			}
 
 			this.prefix = (this.prefix !== '') ? this.prefix + '/' : '';
@@ -77,6 +79,10 @@ export class LocalizableTranslateStaticLoader implements TranslateLoader {
 			}
 		}
 		return obj1;
+	}
+
+	private getWindowPathname(): string {
+		return window.location.pathname;
 	}
 
 }

--- a/projects/systelab-translate/src/lib/systelab-translate.module.ts
+++ b/projects/systelab-translate/src/lib/systelab-translate.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { LocalizableTranslateStaticLoader } from './LocalizableTranslateStaticLoader';
+import { LocalizableTranslateStaticLoader } from './localizable-translate-static-loader';
 import { GeneralTranslatePipe } from './translate.pipe';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { HttpClient } from '@angular/common/http';

--- a/projects/systelab-translate/src/public-api.ts
+++ b/projects/systelab-translate/src/public-api.ts
@@ -6,4 +6,4 @@ export * from './lib/i18n.service';
 export * from './lib/number-format.pipe';
 export * from './lib/translate.pipe';
 export * from './lib/systelab-translate.module';
-
+export * from './lib/localizable-translate-static-loader';

--- a/projects/systelab-translate/src/test/localizable-translate-static-loader.spec.ts
+++ b/projects/systelab-translate/src/test/localizable-translate-static-loader.spec.ts
@@ -1,0 +1,130 @@
+import { LocalizableTranslateStaticLoader } from '../public-api';
+import { HttpClient } from '@angular/common/http';
+import { Location as AngularLocation } from '@angular/common';
+
+describe('LocalizableTranslateStaticLoader Constructor', () => {
+	let httpMock: HttpClient;
+	let locationMock: jasmine.SpyObj<AngularLocation>;
+	let originalGetPathname: () => string;
+
+	beforeEach(() => {
+		httpMock = {} as HttpClient;
+		locationMock = jasmine.createSpyObj('Location', ['path']);
+
+		// Store original method with correct type
+		originalGetPathname = LocalizableTranslateStaticLoader.prototype['getWindowPathname'];
+	});
+
+	afterEach(() => {
+		// Restore original method
+		LocalizableTranslateStaticLoader.prototype['getWindowPathname'] = originalGetPathname;
+	});
+
+	function createLoader(pathname: string, locationPath: string | null = null): LocalizableTranslateStaticLoader {
+		// Mock location.path()
+		if (locationPath === null) {
+			locationMock.path.and.returnValue('');
+		} else {
+			locationMock.path.and.returnValue(locationPath);
+		}
+
+		// Add a mock method to the class prototype to return our test pathname
+		LocalizableTranslateStaticLoader.prototype['getWindowPathname'] = () => pathname;
+
+		return new LocalizableTranslateStaticLoader(httpMock, locationMock);
+	}
+
+	describe('special root paths', () => {
+		it('should set prefix to empty string for root path "/"', () => {
+			const loader = createLoader('/');
+			expect(loader['prefix'])
+				.toBe('');
+		});
+
+		it('should set prefix to empty string for context.html path', () => {
+			const loader = createLoader('/context.html');
+			expect(loader['prefix'])
+				.toBe('');
+		});
+	});
+
+	describe('prefix handling for index.html', () => {
+		it('should remove index.html from the end of the path', () => {
+			const loader = createLoader('/app/folder/index.html');
+			expect(loader['prefix'])
+				.toBe('/app/folder/');
+		});
+
+		it('should handle path with index.html in the middle correctly', () => {
+			const loader = createLoader('/app/index.html/page');
+			expect(loader['prefix'])
+				.toBe('/app/index.html/page/');
+		});
+	});
+
+	describe('trailing slash handling', () => {
+		it('should remove trailing slash from path before processing', () => {
+			const loader = createLoader('/app/folder/');
+			expect(loader['prefix'])
+				.toBe('/app/folder/');
+		});
+
+		it('should add trailing slash to non-empty prefix at the end', () => {
+			const loader = createLoader('/app/folder');
+			expect(loader['prefix'])
+				.toBe('/app/folder/');
+		});
+	});
+
+	describe('location path handling', () => {
+		it('should handle path ending with route that matches location path', () => {
+			const loader = createLoader('/app/dashboard', '/dashboard');
+			expect(loader['prefix'])
+				.toBe('/app/');
+		});
+
+		it('should handle location path with query parameters', () => {
+			const loader = createLoader('/app/dashboard', '/dashboard?param=value');
+			expect(loader['prefix'])
+				.toBe('/app/');
+		});
+
+		it('should not modify prefix when location path does not match the end', () => {
+			const loader = createLoader('/app/other', '/dashboard');
+			expect(loader['prefix'])
+				.toBe('/app/other/');
+		});
+
+		it('should handle empty location path', () => {
+			const loader = createLoader('/app/folder', '');
+			expect(loader['prefix'])
+				.toBe('/app/folder/');
+		});
+
+		// The test for undefined location path needs special handling
+		it('should handle undefined location path by checking explicitly', () => {
+			locationMock.path.and.returnValue(undefined);
+
+			// We need to handle this test case separately since it uses spyOnProperty
+			LocalizableTranslateStaticLoader.prototype['getWindowPathname'] = () => '/somepath';
+
+			const loader = new LocalizableTranslateStaticLoader(httpMock, locationMock);
+			expect(loader['prefix'])
+				.toBe('/somepath/');
+		});
+	});
+
+	describe('complex path combinations', () => {
+		it('should handle path with index.html and matching route', () => {
+			const loader = createLoader('/app/dashboard/index.html', '/dashboard');
+			expect(loader['prefix'])
+				.toBe('/app/');
+		});
+
+		it('should handle path with trailing slash and matching route', () => {
+			const loader = createLoader('/app/dashboard/', '/dashboard');
+			expect(loader['prefix'])
+				.toBe('/app/');
+		});
+	});
+});


### PR DESCRIPTION
- Describe the bug:
The path where bundles are loaded is not found when the redirection is provided from an external application (i.e.: identity provider).

- To Reproduce:
1. Click on 'Sign in with a identity provider' on the login page.
2. Select the identity provider.
3. Log in to the identity provider.
4. The translated texts are wrong showing the key instead of value.

- Expected behavior:
After Logging in to the identity provider and redirecting to the application, the texts must be translated.